### PR TITLE
feat(cli): add CLI with operation mode, IP and port options.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1.0"
+clap = { version = "4.5", features = ["derive"] }
+serde = { version = "1.0", features = ["derive"] }
+tokio = { version = "1.36", features = ["full"] }

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,1 +1,5 @@
+use std::net::IpAddr;
 
+pub async fn start(_ip_addr: Option<IpAddr>, _port: Option<u16>) -> anyhow::Result<()> {
+    todo!("Client main loop!")
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,2 @@
-mod client;
-mod server;
+pub mod client;
+pub mod server;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,46 @@
-fn main() {
-    println!("Hello World!");
+use std::net::IpAddr;
+
+use clap::Parser;
+use omni_node::{client, server};
+use serde::Serialize;
+
+#[derive(clap::ValueEnum, Clone, Default, Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum Mode {
+    /// Mode of operation as client (default).
+    #[default]
+    Client,
+    /// Mode of operation as server.
+    Server,
+}
+
+#[derive(Parser)]
+#[command(version, about, long_about = None)]
+struct Cli {
+    /// Operation mode.
+    #[arg(short, long, value_enum)]
+    mode: Option<Mode>,
+
+    /// Server IP address.
+    #[arg(short, long, default_value = "127.0.0.1")]
+    ip_addr_server: Option<IpAddr>,
+
+    /// Server TCP port.
+    #[arg(short, long, default_value = "9696")]
+    port_server: Option<u16>,
+}
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let cli = Cli::parse();
+
+    match cli.mode {
+        Some(Mode::Server) => {
+            server::start(cli.ip_addr_server, cli.port_server).await?;
+        }
+        _ => {
+            client::start(cli.ip_addr_server, cli.port_server).await?;
+        }
+    }
+
+    Ok(())
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,1 +1,5 @@
+use std::net::IpAddr;
 
+pub async fn start(_ip_addr: Option<IpAddr>, _port: Option<u16>) -> anyhow::Result<()> {
+    todo!("Server main loop!")
+}


### PR DESCRIPTION
All of which are optional and have the following default values: `client`, `127.0.0.1` and `9696`, respectively.